### PR TITLE
[#21 #19] Discovery service fixes

### DIFF
--- a/config/src/main/resources/application.yml
+++ b/config/src/main/resources/application.yml
@@ -4,13 +4,14 @@ spring:
       server:
         native:
           search-locations: classpath:/shared
-#Use some git repo for prod configuration
-#        git:
-#          uri: ${HOME}/projects/config-repo
+  #Use some git repo for prod configuration
+  #        git:
+  #          uri: ${HOME}/projects/config-repo
 
   profiles:
-     active: native
+    active: native
 
   security:
     user:
+      name: ${CONFIG_SERVICE_USER}
       password: ${CONFIG_SERVICE_PASSWORD}

--- a/discovery-service/build.gradle
+++ b/discovery-service/build.gradle
@@ -3,5 +3,9 @@ dependencies {
     compile('org.springframework.boot:spring-boot-starter-actuator')
     compile('org.springframework.cloud:spring-cloud-starter-netflix-eureka-server')
 
+    compile('javax.xml.bind:jaxb-api:2.3.0')
+    compile('javax.activation:activation:1.1')
+    compile('org.glassfish.jaxb:jaxb-runtime:2.3.0')
+
     testCompile('org.springframework.boot:spring-boot-starter-test')
 }

--- a/discovery-service/src/main/resources/application.properties
+++ b/discovery-service/src/main/resources/application.properties
@@ -1,10 +1,4 @@
-server.port=8761
-
-spring.cloud.config.uri=http://config:8888
-spring.cloud.config.password=${CONFIG_SERVICE_PASSWORD}
-spring.cloud.config.username=user
-
-logging.level.com.netflix.eureka=OFF
-logging.level.com.netflix.discovery=OFF
+logging.level.com.netflix.eureka = INFO
+logging.level.com.netflix.discovery = INFO
 
 management.endpoints.web.exposure.include=refresh

--- a/discovery-service/src/main/resources/bootstrap.yml
+++ b/discovery-service/src/main/resources/bootstrap.yml
@@ -1,8 +1,14 @@
+server:
+  port: 8761
+
 spring:
   application:
     name: discovery-service
   cloud:
     config:
+      uri: http://config:8888
+      username: ${CONFIG_SERVICE_USER}
+      password: ${CONFIG_SERVICE_PASSWORD}
       fail-fast: true
 
 eureka:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   config:
     environment:
       CONFIG_SERVICE_PASSWORD: $CONFIG_SERVICE_PASSWORD
+      CONFIG_SERVICE_USER: $CONFIG_SERVICE_USER
     image: turukin/d-echo-config
     restart: always
     logging:
@@ -14,13 +15,12 @@ services:
   eureka:
     environment:
       CONFIG_SERVICE_PASSWORD: $CONFIG_SERVICE_PASSWORD
+      CONFIG_SERVICE_USER: $CONFIG_SERVICE_USER
     image: turukin/d-echo-eureka
     restart: always
     depends_on:
       config:
         condition: service_healthy
-    ports:
-      - 8761:8761
     logging:
       options:
         max-size: "10m"


### PR DESCRIPTION
resolves #21:
- Make Discovery and Config services work together in docker-compose

resolves #19:
- Move Spring Cloud Config credentials to 'bootstrap.[yml | properties]'